### PR TITLE
 [1/2] SystemUI: dont block IME space for back gesture

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4600,6 +4600,12 @@ public final class Settings {
         /** @hide */
         private static final Validator BACK_GESTURE_HEIGHT_VALIDATOR =
                 ANY_INTEGER_VALIDATOR;
+        /** @hide */
+        public static final String BACK_GESTURE_BLOCK_IME = "back_gesture_block_ime";
+
+        /** @hide */
+        private static final Validator BACK_GESTURE_BLOCK_IME_VALIDATOR =
+                BOOLEAN_VALIDATOR;
 
         /**
          * Whether the user has already accepted MediaProjection permission for the built-in screenrecorder
@@ -6887,6 +6893,8 @@ public final class Settings {
             STATUS_BAR_TICKER_TICK_DURATION,
             NAVIGATION_HANDLE_WIDTH,
             STATUS_BAR_CUSTOM_HEADER_HEIGHT,
+            BACK_GESTURE_HAPTIC,
+            BACK_GESTURE_BLOCK_IME,
         };
 
         /**
@@ -7113,6 +7121,7 @@ public final class Settings {
             PRIVATE_SETTINGS.add(STATUS_BAR_TICKER_TICK_DURATION);
             PRIVATE_SETTINGS.add(NAVIGATION_HANDLE_WIDTH);
             PRIVATE_SETTINGS.add(STATUS_BAR_CUSTOM_HEADER_HEIGHT);
+            PRIVATE_SETTINGS.add(BACK_GESTURE_BLOCK_IME);
         }
 
         /**
@@ -7305,6 +7314,7 @@ public final class Settings {
             VALIDATORS.put(DISPLAY_COLOR_ADJUSTMENT, DISPLAY_COLOR_ADJUSTMENT_VALIDATOR);
             VALIDATORS.put(DISPLAY_PICTURE_ADJUSTMENT, DISPLAY_PICTURE_ADJUSTMENT_VALIDATOR);
             VALIDATORS.put(LIVE_DISPLAY_HINTED, LIVE_DISPLAY_HINTED_VALIDATOR);
+	    VALIDATORS.put(BACK_GESTURE_BLOCK_IME,BACK_GESTURE_BLOCK_IME_VALIDATOR);
         }
 
         /**
@@ -18465,3 +18475,4 @@ public final class Settings {
         return packages[0];
     }
 }
+

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/EdgeBackGestureHandler.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/EdgeBackGestureHandler.java
@@ -92,7 +92,11 @@ public class EdgeBackGestureHandler implements DisplayListener {
         @Override
         public void onImeVisibilityChanged(boolean imeVisible, int imeHeight) {
             // No need to thread jump, assignments are atomic
-            mImeHeight = imeVisible ? imeHeight : 0;
+            if (mBlockImeSpace) {
+                mImeHeight = imeVisible ? imeHeight : 0;
+            } else {
+                mImeHeight = 0;
+            }
             // TODO: Probably cancel any existing gesture
         }
 
@@ -182,6 +186,8 @@ public class EdgeBackGestureHandler implements DisplayListener {
 
     // omni additions start
     private int mEdgeHeight;
+    // should back gesture be movewd above ime if its visible
+    private boolean mBlockImeSpace = true;
 
     private IntentFilter mIntentFilter;
 
@@ -215,7 +221,7 @@ public class EdgeBackGestureHandler implements DisplayListener {
         mMinArrowPosition = res.getDimensionPixelSize(R.dimen.navigation_edge_arrow_min_y);
         mFingerOffset = res.getDimensionPixelSize(R.dimen.navigation_edge_finger_offset);
         updateCurrentUserResources(res);
-
+	onSettingsChanged();
         mIntentFilter = new IntentFilter();
         mIntentFilter.addAction(Intent.ACTION_PACKAGE_REMOVED);
         mIntentFilter.addDataScheme("package");
@@ -291,6 +297,8 @@ public class EdgeBackGestureHandler implements DisplayListener {
 
     public void onSettingsChanged() {
         updateEdgeHeightValue();
+        mBlockImeSpace = Settings.System.getIntForUser(mContext.getContentResolver(),
+                Settings.System.BACK_GESTURE_BLOCK_IME, 1, UserHandle.USER_CURRENT) == 1;
     }
 
     private void disposeInputChannel() {
@@ -784,3 +792,4 @@ public class EdgeBackGestureHandler implements DisplayListener {
         }
     }
 }
+

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationModeController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationModeController.java
@@ -185,6 +185,9 @@ public class NavigationModeController implements Dumpable {
                 Settings.System.BACK_GESTURE_HEIGHT),
                 false, mSettingsObserver, UserHandle.USER_ALL);
         mContext.getContentResolver().registerContentObserver(Settings.System.getUriFor(
+                Settings.System.BACK_GESTURE_BLOCK_IME),
+                false, mSettingsObserver, UserHandle.USER_ALL);
+        mContext.getContentResolver().registerContentObserver(Settings.System.getUriFor(
                 Settings.System.NAVIGATION_HANDLE_WIDTH),
                 false, mSettingsObserver, UserHandle.USER_ALL);
         IntentFilter preferredActivityFilter = new IntentFilter(ACTION_PREFERRED_ACTIVITY_CHANGED);
@@ -441,3 +444,4 @@ public class NavigationModeController implements Dumpable {
         }
     }
 }
+


### PR DESCRIPTION
by default if ime is visible the back gesture region starts
above the ime height. add an option to disable that
behaviour so that the back gesture stays the same

Change-Id: I576bb480059b8a531dd7f99f6b4f357fe310969f
Signed-off-by: Joey Huab <joey@evolution-x.org>